### PR TITLE
fix: move timestamp to new line

### DIFF
--- a/registry/new-york/discord-base/discord-base.tsx
+++ b/registry/new-york/discord-base/discord-base.tsx
@@ -117,10 +117,10 @@ function DiscordMessageAuthorName({
 	...props
 }: React.ComponentProps<"p"> & { timestamp: Date; hr24?: boolean }) {
 	return (
-		<div className="flex items-center gap-2">
+		<div className="flex flex-wrap items-center sm:flex-nowrap">
 			<p
 				data-slot="discord-message-author-name"
-				className={cn("font-medium text-[1rem]", className)}
+				className={cn("font-medium text-[1rem] mr-1", className)}
 				{...props}
 			>
 				{children}


### PR DESCRIPTION
Using inspect element I figured out how discord does it (hence why I removed gap-2 and added mr-1) and moved the timestamp to a new line using flex-nowrap.

Looks like this now:
<img width="218" alt="image" src="https://github.com/user-attachments/assets/e9e5186b-12de-496e-af43-f853e54a91cd" />
